### PR TITLE
use get_captures_at_pos for nvim 0.8

### DIFF
--- a/lua/hidesig/highlight_utils.lua
+++ b/lua/hidesig/highlight_utils.lua
@@ -14,6 +14,14 @@ function highlight_utils.get_treesitter_hl(bufnr, row, col)
     return {}
   end
 
+  if vim.fn.has('nvim-0.8') == 1 then
+    local matches = vim.treesitter.get_captures_at_pos(bufnr, row, col)
+
+    return vim.tbl_map(function(match)
+      return "@" .. match.capture
+    end, matches)
+  end
+
   local matches = {}
 
   rubyHighlighter.tree:for_each_tree(function(tstree, tree)


### PR DESCRIPTION
0.8 deprecated `_get_hl_from_capture`, following dim.lua's lead here and using `get_captures_at_pos` if we see nvim 0.8