### PR TITLE
Dim T.type_alias statements

### DIFF
--- a/lua/hidesig.lua
+++ b/lua/hidesig.lua
@@ -7,7 +7,7 @@ function M.init()
     hidesig = {
       module_path = "hidesig.main",
       is_supported = function(lang)
-        local isSupported = queries.get_query(lang, "sig_def") ~= nil
+        local isSupported = queries.get_query(lang, "sorbet") ~= nil
         return isSupported
       end,
       opacity = 0.75

--- a/lua/hidesig/internal.lua
+++ b/lua/hidesig/internal.lua
@@ -68,7 +68,7 @@ function hidesig.highlightLines(bufnr, range, tree, lang, opacity)
   end
 
   local rootNode = tree:root()
-  local parsedQuery = ts_query.get_query(lang, "sig_def")
+  local parsedQuery = ts_query.get_query(lang, "sorbet")
 
   local startRow = range[1]
   local endRow = range[2]
@@ -76,7 +76,7 @@ function hidesig.highlightLines(bufnr, range, tree, lang, opacity)
   vim.api.nvim_buf_clear_namespace(bufnr, namespace, startRow, endRow)
 
   for _, captures in parsedQuery:iter_matches(rootNode, bufnr, startRow, endRow) do
-    local sigBlock = captures[2] -- capture @sig_def
+    local sigBlock = captures[2] -- capture @sorbet
 
     if sigBlock ~= nil and not sigBlock:has_error() then
       for rootChildNode in sigBlock:iter_children() do

--- a/queries/ruby/sig_def.scm
+++ b/queries/ruby/sig_def.scm
@@ -1,6 +1,0 @@
-(
-  call
-    method: (identifier) @sig_keyword
-    block:  [(block) (do_block)]
-  (#eq? @sig_keyword "sig")
-) @sig_def

--- a/queries/ruby/sorbet.scm
+++ b/queries/ruby/sorbet.scm
@@ -1,0 +1,17 @@
+(
+  call
+    method: (identifier) @sig_keyword
+    block:  [(block) (do_block)]
+  (#eq? @sig_keyword "sig")
+) @sorbet
+
+(
+  assignment
+    left: (constant)
+    right: (
+      call
+        receiver: (constant)
+        method: (identifier) @alias_identifier
+        (#eq? @alias_identifier "type_alias")
+    )
+) @sorbet


### PR DESCRIPTION
Allows dimming of type_alias statements in addition to `sig`s. I've found the type aliases to be distracting, so decided to dim them as well.

<img width="516" alt="Screenshot 2024-10-31 at 10 53 20 AM" src="https://github.com/user-attachments/assets/33f7e097-de6a-4889-a04d-b3969d6ad660">

I wasn't sure if it was worth adding a setting that enables/disables this, but I decided to keep things simple.